### PR TITLE
Feat/collate mode -- collate project files into output file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
-# Compiler
-CC = gcc
+# Detect operating system
+UNAME_S := $(shell uname -s)
+
+# Check for Homebrew LLVM on macOS, fallback to system clang
+ifeq ($(UNAME_S),Darwin)
+    HOMEBREW_LLVM := $(shell test -x /opt/homebrew/opt/llvm/bin/clang && echo "yes")
+    ifeq ($(HOMEBREW_LLVM),yes)
+        CC = /opt/homebrew/opt/llvm/bin/clang
+    else
+        CC = clang
+        $(warning On macOS, Homebrew LLVM is recommended for leak detection. Install with: brew install llvm)
+    endif
+else
+    CC = clang
+endif
 
 # Compiler flags
 WARNING_FLAGS = -Wall -Werror -Wextra
@@ -14,6 +27,7 @@ LDFLAGS =
 SRC_DIR = src
 OBJ_DIR = obj
 BIN_DIR = bin
+SCRIPT_DIR = tests
 
 # Find all source files
 SOURCES = $(wildcard $(SRC_DIR)/*.c)
@@ -21,18 +35,42 @@ OBJECTS = $(SOURCES:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 EXECUTABLE = $(BIN_DIR)/colette
 
 # Build targets
-.PHONY: all debug release clean rebuild directories install
+.PHONY: all memcheck debug test release clean rebuild directories install
 
 # Main target
 all: release
 
 # Debug target
 debug: DEBUG = 1
-debug: CFLAGS += -fsanitize=address -DDBUG -g -O0
-debug: LDFLAGS += -fsanitize=address
+debug: CFLAGS += -DDBUG -g -O0
 debug: directories $(EXECUTABLE)
 
-# Debug target
+# Memcheck flags based on compiler
+ifeq ($(HOMEBREW_LLVM),yes)
+    MEMCHECK_SANITIZE = -fsanitize=address,leak
+else
+    MEMCHECK_SANITIZE = -fsanitize=address
+endif
+
+# Memcheck target
+# Allows program to continue after finding issues
+MEMCHECK_SANITIZE += -fsanitize-recover=address,leak
+# Still halt on undefined behavior
+MEMCHECK_SANITIZE += -fno-sanitize-recover=undefined
+# Better stack traces
+MEMCHECK_SANITIZE += -fno-omit-frame-pointer
+MEMCHECK_SANITIZE += -fno-optimize-sibling-calls
+memcheck: DEBUG = 1
+memcheck: CFLAGS += $(MEMCHECK_SANITIZE) -DDBUG -g -O0 -fno-inline
+memcheck: LDFLAGS += $(MEMCHECK_SANITIZE)
+memcheck: directories $(EXECUTABLE)
+	$(SCRIPT_DIR)/run_memcheck.sh
+
+# Test target
+test: debug
+	$(SCRIPT_DIR)/run_tests.sh
+
+# Release target
 release: DEBUG = 0
 release: CFLAGS += -O2
 release: directories $(EXECUTABLE)
@@ -57,8 +95,11 @@ clean:
 
 rebuild: clean all
 rebuild-debug: clean debug
+rebuild-memcheck: clean memcheck
+rebuild-test: clean test
 rebuild-release: clean release
 
 install: all
+	echo $(shell gcc --version | grep ^gcc | sed 's/^.* //g')
 	mkdir -p ~/bin
 	cp $(EXECUTABLE) ~/bin/

--- a/src/args.c
+++ b/src/args.c
@@ -38,8 +38,8 @@ static bool isValidFilenameChar(char c) {
     return true;
 }
 
-static unsigned int stringToUint(const char *str, char **endptr,
-                                 bool *success) {
+static unsigned int
+stringToUint(const char *str, char **endptr, bool *success) {
     if (!str || !success) {
         if (success) {
             *success = false;
@@ -76,7 +76,9 @@ static char *validateDirectory(char *directoryArg, enum ArgError *status) {
             *status = ARG_INVALID_DIR;
             break;
         default:
-            fprintf(stderr, "Error resolving path %s: %s\n", directory,
+            fprintf(stderr,
+                    "Error resolving path %s: %s\n",
+                    directory,
                     strerror(errno));
             *status = ARG_INVALID_DIR;
         }
@@ -142,6 +144,7 @@ static char *validateTitle(char *titleArg, enum ArgError *status) {
     for (size_t i = 1; i < outLen - 1; i++) {
         if (!isValidFilenameChar(titleBuf[i])) {
             *status = ARG_INVALID_TITLE;
+            free(titleBuf);
             return NULL;
         }
         if (isspace(titleBuf[i])) {
@@ -245,10 +248,6 @@ const char *getUsageString(void) {
 }
 
 void freeArguments(struct Arguments *args) {
-    if (args->directory != NULL) {
-        free(args->directory);
-    }
-    if (args->title != NULL) {
-        free(args->title);
-    }
+    free(args->directory);
+    free(args->title);
 }

--- a/src/args.c
+++ b/src/args.c
@@ -27,8 +27,46 @@ static struct option longOpts[] = {
     {"title", required_argument, NULL, 't'},
     {"prefix", required_argument, NULL, 'p'},
     // {"output", required_argument, NULL, 'o'},
-    {0, 0, 0, 0} // array terminator
+    {0, 0, 0, 0}  // array terminator
 };
+
+static const char *argErrorToString(enum ArgError error) {
+    switch (error) {
+    case ARG_SUCCESS:
+        return "Success";
+    case ARG_MISSING_DIR:
+        return "Error: No directory specified";
+    case ARG_INVALID_DIR:
+        return "Error: Invalid directory path";
+    case ARG_MISSING_PADDING:
+        return "Error: Prefix padding value required";
+    case ARG_INVALID_PADDING:
+        return "Error: Invalid prefix padding value";
+    case ARG_PADDING_RANGE:
+        return "Error: Prefix padding must be a value from 1 to 10";
+    case ARG_MISSING_TITLE:
+        return "Error: Title value required";
+    case ARG_INVALID_TITLE:
+        return "Error: Invalid title";
+    case ARG_NO_DIR_ACCESS:
+        return "Error: Cannot access directory";
+    case ARG_CONFLICTING_FLAGS:
+        return "Error: Conflicting options specified";
+    case ARG_INVALID_OPT:
+        return "Error: Invalid option";
+    case ARG_MEMORY_ERROR:
+        return "Error: Memory allocation failed";
+    case ARG_USAGE_MSG:
+        return "Usage: colette [-i|--init] [-c|--check] [-a|--as-list] "
+               "[-p|--prefix] PREFIX_PADDING DIRECTORY";
+    default:
+        return "Unknown error";
+    }
+}
+
+static const char *getUsageString(void) {
+    return USAGE_STRING;
+}
 
 static bool isValidFilenameChar(char c) {
     if (c == '/' || c == '\0' || iscntrl(c)) {
@@ -63,8 +101,10 @@ static char *validateDirectory(char *directoryArg, enum ArgError *status) {
     char *resolvedPath;
     char *directory = directoryArg ? directoryArg : ".";
 
-    // null pointer in resolved_name arg mallocs buffer for return value
-    // rememeber to free()!
+    /* *
+    * null pointer in resolved_name arg mallocs buffer for return value
+    * rememeber to free()!
+    * */
     resolvedPath = realpath(directory, NULL);
     if (resolvedPath == NULL) {
         *status = ARG_INVALID_DIR;
@@ -122,7 +162,7 @@ static char *validateTitle(char *titleArg, enum ArgError *status) {
     }
 
     size_t titleLen = strlen(titleArg);
-    size_t outLen = titleLen + 3; // title + underscores + null terminator
+    size_t outLen = titleLen + 3;  // title + underscores + null terminator
 
     if (outLen > COLETTE_NAME_BUF_SIZE) {
         *status = ARG_INVALID_TITLE;
@@ -207,44 +247,6 @@ struct Arguments parseArgs(int argc, char **argv) {
     }
 
     return args;
-}
-
-const char *argErrorToString(enum ArgError error) {
-    switch (error) {
-    case ARG_SUCCESS:
-        return "Success";
-    case ARG_MISSING_DIR:
-        return "Error: No directory specified";
-    case ARG_INVALID_DIR:
-        return "Error: Invalid directory path";
-    case ARG_MISSING_PADDING:
-        return "Error: Prefix padding value required";
-    case ARG_INVALID_PADDING:
-        return "Error: Invalid prefix padding value";
-    case ARG_PADDING_RANGE:
-        return "Error: Prefix padding must be a value from 1 to 10";
-    case ARG_MISSING_TITLE:
-        return "Error: Title value required";
-    case ARG_INVALID_TITLE:
-        return "Error: Invalid title";
-    case ARG_NO_DIR_ACCESS:
-        return "Error: Cannot access directory";
-    case ARG_CONFLICTING_FLAGS:
-        return "Error: Conflicting options specified";
-    case ARG_INVALID_OPT:
-        return "Error: Invalid option";
-    case ARG_MEMORY_ERROR:
-        return "Error: Memory allocation failed";
-    case ARG_USAGE_MSG:
-        return "Usage: colette [-i|--init] [-c|--check] [-a|--as-list] "
-               "[-p|--prefix] PREFIX_PADDING DIRECTORY";
-    default:
-        return "Unknown error";
-    }
-}
-
-const char *getUsageString(void) {
-    return USAGE_STRING;
 }
 
 void freeArguments(struct Arguments *args) {

--- a/src/args.h
+++ b/src/args.h
@@ -3,40 +3,64 @@
 
 #include <stdbool.h>
 
+/**
+ * Possible error states when parsing command line arguments.
+ */
 enum ArgError {
-    ARG_SUCCESS = 0,
-    ARG_MISSING_DIR,
-    ARG_INVALID_DIR,
-    ARG_MISSING_PADDING,
-    ARG_INVALID_PADDING,
-    ARG_PADDING_RANGE,
-    ARG_MISSING_TITLE,
-    ARG_INVALID_TITLE,
-    ARG_NO_DIR_ACCESS,
-    ARG_CONFLICTING_FLAGS,
-    ARG_INVALID_OPT,
-    ARG_MEMORY_ERROR,
-    ARG_USAGE_MSG,
+    ARG_SUCCESS,              // Arguments parsed successfully
+    ARG_MISSING_DIR,          // No directory argument provided
+    ARG_INVALID_DIR,          // Root directory path is invalid
+    ARG_MISSING_PADDING,      // No padding value provided with -p flag
+    ARG_INVALID_PADDING,      // Padding value is not a valid number
+    ARG_PADDING_RANGE,        // Padding value outside allowed range (1-10)
+    ARG_MISSING_TITLE,        // No title provided with -t flag
+    ARG_INVALID_TITLE,        // Title contains invalid characters
+    ARG_NO_DIR_ACCESS,        // Cannot access specified directory
+    ARG_CONFLICTING_FLAGS,    // Incompatible flags used together
+    ARG_INVALID_OPT,          // Unknown option flag provided
+    ARG_MEMORY_ERROR,         // Memory allocation failed
+    ARG_USAGE_MSG,            // Show usage message
 };
 
+/**
+ * Operating modes that determine if and how files are processed.
+ */
 enum ProcessMode {
-    MODE_COLLATE = 0,
+    MODE_COLLATE,
     MODE_LIST,
     MODE_CHECK,
 };
 
+/* *
+ * Arguments struct holds parsed and validated command line arguments for use
+ * in processProject to initialize state and determine behavior.
+ * */
 struct Arguments {
-    char *directory;
-    char *title;
-    bool initMode;
-    enum ProcessMode mode;
-    unsigned int prefixPadding;
-    enum ArgError status;
+    char *directory;             // Path to project root directory
+    char *title;                 // Name of output file or directory
+    bool initMode;               // --init flag used
+    enum ProcessMode mode;       // check, collate, list
+    unsigned int prefixPadding;  // number of digits in output numeric prefix
+    enum ArgError status;        // status of parsing for error reporting
 };
 
+/* *
+ * Parses command line arguments into an Arguments structure. Validates all
+ * arguments and sets appropriate error status.
+ *
+ * @param   argc       Number of command line arguments
+ * @param   argv       Array of command line argument strings
+ * @return  Arguments  structure containing parsed values
+ *
+ * Note: Caller must call freeArguments() on returned structure
+ * */
 struct Arguments parseArgs(int argc, char *argv[]);
-const char *argErrorToString(enum ArgError error);
-const char *getUsageString(void);
+
+/* *
+ * Frees memory allocated within an Arguments structure.
+ *
+ * @param  args  Pointer to Arguments structure to free
+ * */
 void freeArguments(struct Arguments *args);
 
 #endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,15 +1,29 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-// Common system page size. Should be large enough buffer for most paths
+/* *
+ * Common system page size. Should be large enough buffer for most paths
+ * */
 #define COLETTE_PATH_BUF_SIZE 4096
 #define COLETTE_MAX_PATH_LEN (COLETTE_PATH_BUF_SIZE - 1)
-// Common system filename size
+
+/* *
+ * Common system filename size
+ * */
 #define COLETTE_NAME_BUF_SIZE 255
-// Reasonable buffer size for file name extension
+
+/* *
+ * Reasonable buffer size for file name extension
+ * */
 #define COLETTE_EXT_BUF_SIZE 16
-// Size of read buffer for file collation
+
+/* *
+ * Size of read buffer for file collation
+ * */
 #define COLETTE_FILE_BUF_SIZE 8192
-// Initial project depth value allows for 5 layers of nesting.
+
+/* *
+ * Initial project depth value allows for 5 layers of nesting.
+ * */
 #define COLETTE_PROJECT_DEPTH 5
 #endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -6,6 +6,10 @@
 #define COLETTE_MAX_PATH_LEN (COLETTE_PATH_BUF_SIZE - 1)
 // Common system filename size
 #define COLETTE_NAME_BUF_SIZE 255
+// Reasonable buffer size for file name extension
+#define COLETTE_EXT_BUF_SIZE 16
+// Size of read buffer for file collation
+#define COLETTE_FILE_BUF_SIZE 8192
 // Initial project depth value allows for 5 layers of nesting.
 #define COLETTE_PROJECT_DEPTH 5
 #endif

--- a/src/errors.h
+++ b/src/errors.h
@@ -7,25 +7,12 @@ enum FileOperation {
     FILE_OP_OPEN,      // Opening files (will need this for index files)
     FILE_OP_READ,      // Reading from files (will need this for collation)
     FILE_OP_WRITE,     // Writing to files (will need this for output)
+    FILE_OP_JOIN,
     PATH_OP_VALIDATE,  // Input validation checks
     PATH_OP_COMPONENT, // Path component validation
     PATH_OP_ABS_FILE,
     PATH_OP_BUFFER,    // Buffer management
     PATH_OP_JOIN       // Path joining operation
-};
-
-enum PathStatus {
-    PATH_SUCCESS,
-    PATH_NULL_INPUT,
-    PATH_EMPTY_INPUT,
-    PATH_BUFFER_TOO_SMALL,
-    PATH_BUFFER_TOO_LARGE,
-    PATH_TOO_LONG,
-    PATH_NAME_TOO_LONG,
-    PATH_INVALID_CHAR,
-    PATH_ABS_NOT_ALLOWED,
-    PATH_MEMORY_ERROR,
-    PATH_INVALID_EXT,
 };
 
 enum ResolveStatus {
@@ -85,6 +72,7 @@ enum ProcessErrorDetail {
     PROC_ERR_INVALID_SEQUENCE, // Operations in wrong order
     PROC_ERR_INVALID_LINK,     // Symbolic links not allowed
     PROC_ERR_INVALID_PATH,
+    PROC_ERR_INVALID_OUTPUT,
     PROC_ERR_FILE_NOT_FOUND,
 
     // Permission errors
@@ -102,15 +90,6 @@ enum ProcessErrorDetail {
 
     // Other
     PROC_ERR_OPEN_FILE
-};
-
-enum IndexStateStatus {
-    INDEX_SUCCESS,
-    INDEX_FILE_ERROR,
-    INDEX_MEMORY_ERROR,
-    INDEX_OVERFLOW_ERROR,
-    INDEX_TOO_LARGE,
-    INDEX_PATH_TOO_LONG,
 };
 
 enum FileIteratorStatus {

--- a/src/files.c
+++ b/src/files.c
@@ -33,15 +33,6 @@ bool isIncluded(const char *fileName) {
     if (fileName == NULL || fileName[0] == '\0') {
         return false;
     }
-    /**
-     * Hidden files are denoted with a '.' or '_' prefix. User-created files
-     * are prefixed with '_' to be ignored. For example: `_notes.md` could be
-     * a file used to keep notes not intended to be included in the document.
-     * Dot-prefixed files are normal POSIX hidden files and include `.index`
-     * files to be used to organize the document. Finally, output file names
-     * will be surrounded by underscores i.e. `_Title_.md` to both filter them
-     * from collation and visually differentiate them from other project files.
-     **/
     return (fileName[0] != '.' && fileName[0] != '_');
 }
 

--- a/src/files.c
+++ b/src/files.c
@@ -71,8 +71,7 @@ resolveFile(char *buffer, size_t buffSize, const char *path) {
 
     const char **extensions = getSupportedExtensions();
     while (*extensions != NULL) {
-        if (joinExtension(buffer, buffSize, path, *extensions) !=
-            PATH_SUCCESS) {
+        if (joinExtension(buffer, buffSize, path, *extensions) != 0) {
             return RESOLVE_ERROR;
         }
 
@@ -91,9 +90,8 @@ resolveFile(char *buffer, size_t buffSize, const char *path) {
 
     return RESOLVE_NOT_FOUND;
 }
-
-int getBasename(const char *path, char *buffer, size_t size) {
-    if (!path || !buffer || size == 0) {
+int getBasename(char *buffer, const char *path, size_t size) {
+    if (!buffer || !path || size == 0) {
         return -1;
     }
 
@@ -122,19 +120,18 @@ int handlePathBufTrailingSlashPad(const char *path, size_t pathLen) {
     return hasTrailingSlash ? 1 : 2; // slash and null terminator
 }
 
-enum PathStatus
-joinPath(char *buffer, size_t buffSize, const char *dir, const char *file) {
+int joinPath(char *buffer, size_t buffSize, const char *dir, const char *file) {
     if (!dir || !file || !buffer) {
         reportFileError(PATH_OP_VALIDATE, "path joining");
-        return PATH_NULL_INPUT;
+        return -1;
     }
     if (buffSize > COLETTE_PATH_BUF_SIZE) {
         reportFileError(PATH_OP_BUFFER, dir);
-        return PATH_BUFFER_TOO_LARGE;
+        return -1;
     }
     if (dir[0] == '\0' || file[0] == '\0') {
         reportFileError(PATH_OP_VALIDATE, "path joining");
-        return PATH_EMPTY_INPUT;
+        return -1;
     }
 
     size_t dirLen = strnlen(dir, buffSize);
@@ -142,24 +139,23 @@ joinPath(char *buffer, size_t buffSize, const char *dir, const char *file) {
     if (dirLen >= buffSize || fileLen >= buffSize) {
         // strnlen did not encounter null terminator
         reportFileError(PATH_OP_VALIDATE, "path joining");
-        return PATH_TOO_LONG;
+        return -1;
     }
 
     if (file[0] == '/') {
-        fprintf(stderr, "DEBUG -- file starts with a slash (absolute)");
         reportFileError(PATH_OP_ABS_FILE, file);
-        return PATH_ABS_NOT_ALLOWED;
+        return -1;
     }
     if (fileLen > COLETTE_NAME_BUF_SIZE) {
         reportFileError(PATH_OP_COMPONENT, file);
-        return PATH_NAME_TOO_LONG;
+        return -1;
     }
 
     int extraChars = handlePathBufTrailingSlashPad(dir, dirLen);
 
     if (dirLen + fileLen + extraChars > COLETTE_MAX_PATH_LEN) {
         reportFileError(PATH_OP_JOIN, "path joining");
-        return PATH_TOO_LONG;
+        return -1;
     }
 
     memcpy(buffer, dir, dirLen);
@@ -172,45 +168,68 @@ joinPath(char *buffer, size_t buffSize, const char *dir, const char *file) {
     memcpy(buffer + dirLen, file, fileLen);
     buffer[dirLen + fileLen] = '\0';
 
-    return PATH_SUCCESS;
+    return 0;
 }
 
-enum PathStatus joinExtension(char *buffer,
-                              size_t buffSize,
-                              const char *file,
-                              const char *ext) {
+int joinExtension(char *buffer,
+                  size_t buffSize,
+                  const char *file,
+                  const char *ext) {
     if (!file || !ext || !buffer) {
-        reportFileError(FILE_OP_ACCESS, "extension joining");
-        return PATH_NULL_INPUT;
+        errno = 0; // ideally we shouldn't be relying on errno for reporting
+        reportFileError(FILE_OP_JOIN, "extension joining");
+        return -1;
     }
     if (buffSize > COLETTE_PATH_BUF_SIZE) {
         reportFileError(FILE_OP_ACCESS, file);
-        return PATH_BUFFER_TOO_LARGE;
+        return -1;
     }
     if (file[0] == '\0' || ext[0] == '\0') {
         reportFileError(FILE_OP_ACCESS, "extension joining");
-        return PATH_EMPTY_INPUT;
+        return -1;
     }
     if (ext[0] != '.') {
         reportFileError(FILE_OP_ACCESS, "extension joining");
-        return PATH_INVALID_EXT;
+        return -1;
     }
 
     size_t fileLen = strnlen(file, buffSize);
-    size_t extLen = strnlen(ext, COLETTE_NAME_BUF_SIZE) + 1;
-    if (extLen >= COLETTE_NAME_BUF_SIZE || fileLen >= buffSize) {
+    size_t extLen = strnlen(ext, COLETTE_EXT_BUF_SIZE);
+    if (extLen >= COLETTE_EXT_BUF_SIZE || fileLen >= buffSize) {
         // strnlen did not encounter null terminator
-        reportFileError(FILE_OP_ACCESS, "extension joining");
-        return PATH_TOO_LONG;
+        reportFileError(FILE_OP_JOIN, "extension joining");
+        return -1;
+    }
+    if (fileLen + extLen > buffSize) {
+        reportFileError(FILE_OP_JOIN, "extension joining");
+        return -1;
     }
 
-    if (fileLen + extLen > COLETTE_MAX_PATH_LEN) {
-        reportFileError(FILE_OP_ACCESS, "extension joining");
-        return PATH_TOO_LONG;
+    if (fileLen + extLen + 1 > COLETTE_MAX_PATH_LEN) {
+        reportFileError(FILE_OP_JOIN, "extension joining");
+        return -1;
+    }
+
+    char baseName[COLETTE_NAME_BUF_SIZE];
+    if (getBasename(baseName, file, COLETTE_NAME_BUF_SIZE) != 0) {
+        reportFileError(FILE_OP_JOIN, "extension joining");
+        return -1;
+    }
+    size_t baseNameLen = strlen(baseName) + 1;
+    if (baseNameLen + extLen > COLETTE_NAME_BUF_SIZE) {
+        /* *
+         * TODO: Improve file error reporting to make it more like process error
+         * reporting. Using errno for error messages is largely unhelpful to the
+         * end user in cases like this where the filename is too long. This is
+         * an error generated by colette, not a system error.
+         * */
+        reportFileError(FILE_OP_JOIN, "extension joining");
+        return -1;
     }
 
     memcpy(buffer, file, fileLen);
     memcpy(buffer + fileLen, ext, extLen); // copy ext at end of file in buffer
+    buffer[fileLen + extLen] = '\0';
 
-    return PATH_SUCCESS;
+    return 0;
 }

--- a/src/files.h
+++ b/src/files.h
@@ -9,10 +9,11 @@
 bool isIncluded(const char *fileName);
 // int getFileStatus(struct stat *statBuf, const char *path);
 enum ResolveStatus resolveFile(char *buffer, size_t buffSize, const char *path);
-int getBasename(const char *path, char *buffer, size_t size);
+int getBasename(char *buffer, const char *path, size_t size);
 int handlePathBufTrailingSlashPad(const char *path, size_t pathLen);
-enum PathStatus
-joinPath(char *buffer, size_t buffSize, const char *dir, const char *file);
-enum PathStatus
-joinExtension(char *buffer, size_t buffSize, const char *file, const char *ext);
+int joinPath(char *buffer, size_t buffSize, const char *dir, const char *file);
+int joinExtension(char *buffer,
+                  size_t buffSize,
+                  const char *file,
+                  const char *ext);
 #endif /* FILES_H */

--- a/src/files.h
+++ b/src/files.h
@@ -6,12 +6,106 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
+/**
+ * Determines if a file or directory is to be included in the final output.
+ *
+ * Hidden files are denoted with a '.' or '_' prefix. User-created files are to
+ * be prefixed with '_' to be ignored. For example: `_notes.md` could be a file
+ * used to keep notes not intended to be included in the document. Dot-prefixed
+ * files are normal POSIX hidden files and include `.index` files to be used to
+ * organize the document. Finally, output file names will be surrounded by
+ * underscores i.e. `_Title_.md` to both filter them from collation and
+ * visually differentiate them from other project files.
+ *
+ * @param   fileName  Name of file or directory to be checked
+ *
+ * @return  bool
+ *          true      if file should be included in finale output
+ *          false     if file should be ignored
+ **/
 bool isIncluded(const char *fileName);
-// int getFileStatus(struct stat *statBuf, const char *path);
+
+/* *
+ * Distinguishes between directories and regular files and symbolic links.
+ * Buffer must be large enough to hold the path and longest supported extension.
+ *
+ * @param   buffer             Output buffer to store resolved path
+ * @param   buffSize           Size of output buffer
+ * @param   path               Path to resolve
+ *
+ * @return  ResolveStatus      indicating result:
+ *          RESOLVE_ERROR      General error occurred
+ *          RESOLVE_NO_ACCESS  Permission denied
+ *          RESOLVE_NOT_FOUND  No matching file found
+ *          RESOLVE_LINK       Found symbolic link (not allowed)
+ *          RESOLVE_DIR        Found a directory
+ *          RESOLVE_FILE       Found file with added extension
+ *          RESOLVE_EXACT      Found exact match
+ * */
 enum ResolveStatus resolveFile(char *buffer, size_t buffSize, const char *path);
+
+/* *
+ * Wrapper around POSIX basename() with added buffer safety. Extracts the
+ * basename (filename) from a path string. Handles trailing slashes.
+ *
+ * @param   buffer  Output buffer for basename
+ * @param   path    Full path to extract basename from
+ * @param   size    Size of output buffer
+ *
+ * @return  int
+ *          0       on success
+ *         -1       on error
+ *
+ * */
 int getBasename(char *buffer, const char *path, size_t size);
+
+/* *
+ * Calculates padding needed for path joining with trailing slash handling.
+ * Used to ensure proper buffer allocation for path construction.
+ *
+ * @param   path     Path to analyze
+ * @param   pathLen  Length of the path
+ *
+ * @return  int
+ *          1        if path has trailing slash
+ *          2        if path doesn't have trailing slash
+ *         (accounts for added slash and null terminator)
+ * */
 int handlePathBufTrailingSlashPad(const char *path, size_t pathLen);
+
+/* *
+ * Safely joins directory and file paths, preventing directory traversal.
+ * Ensures resulting path stays within project boundaries. Handles missing
+ * trailing slashes, prevents directory traversal, validates buffer sizes and
+ * path components.
+ *
+ * @param   buffer    Output buffer for joined path
+ * @param   buffSize  Size of output buffer
+ * @param   dir       Directory path
+ * @param   file      File path to append (must not be absolute)
+ *
+ * @return  int
+ *          0         on success
+ *         -1         on error
+ *
+ * */
 int joinPath(char *buffer, size_t buffSize, const char *dir, const char *file);
+
+/* *
+ * Safely appends a file extension to a path. Validates both the base path and
+ * extension. Validates extension format, handles buffer sizes, ensures
+ * resulting filename is valid.
+ *
+ * @param   buffer    Output buffer for path with extension
+ * @param   buffSize  Size of output buffer
+ * @param   file      Base file path
+ * @param   ext       Extension to append (must start with '.')
+ *
+ * @return  int
+ *          0         on success
+ *         -1         on error
+ *
+ * */
 int joinExtension(char *buffer,
                   size_t buffSize,
                   const char *file,

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 int main(int argc, char *argv[]) {
     struct Arguments args = parseArgs(argc, argv);
     if (args.status != ARG_SUCCESS) {
+        freeArguments(&args);
         return EXIT_FAILURE;
     }
 

--- a/src/process.h
+++ b/src/process.h
@@ -68,14 +68,15 @@ struct ProjectState {
  * index files, processing project files in the order they appear in
  * the index files.
  *
- * @param args  Command line arguments included when the program is executed.
+ * @param   args  Command line arguments included when the program is executed.
  *
- * @return 0 if process completes without and errors.
- *         -1 if any error occurs during the process including:
- *             - state intitialization
- *             - index file traversal
- *             - project file traversal/processing
- *             - output writing
+ * @return  int
+ *          0     if process completes without and errors.
+ *         -1     if any error occurs during the process including:
+ *                    - state intitialization
+ *                    - index file traversal
+ *                    - project file traversal/processing
+ *                    - output writing
  * */
 int processProject(struct Arguments *args);
 

--- a/src/process.h
+++ b/src/process.h
@@ -5,17 +5,27 @@
 #include "errors.h"
 #include <stdio.h>
 
-enum FileType {
-    FILE_TYPE_UNKNOWN,
-    FILE_TYPE_DIRECTORY,
-    FILE_TYPE_REGULAR
-};
+enum FileType { FILE_TYPE_UNKNOWN, FILE_TYPE_DIRECTORY, FILE_TYPE_REGULAR };
 
+/* *
+ * Index state stores the path to an index file as well as a file pointer to
+ * the open index file. It is used with FileIterator to keep track of and read
+ * index files while traversing a project.
+ * */
 struct IndexState {
     char *curIndexFileDir;
     FILE *curIndexFile;
 };
 
+/* *
+ * FileIterator is a stack that keeps track of the programs position in a
+ * project as well as providing limits for the project depth and a status to
+ * indicate if an error has occured in the process of traversing the project.
+ *
+ * NOTE: stackMax will eventually be user-configurable but for now defaults to
+ * 5 levels of nesting, which is what I've determined to be sufficient based on
+ * my prejudices against complexity.
+ * */
 struct FileIterator {
     struct IndexState *stack; // pointer == array
     size_t stackSize;
@@ -23,6 +33,13 @@ struct FileIterator {
     enum FileIteratorStatus status;
 };
 
+/* *
+ * ProcessContext keeps track of the project files and their types as they are
+ * being processed. It also contains the output file pointer (if collate mode
+ * is being used), the output path as well as the status of the context to halt
+ * if there is an error. The name of the output file or directory can be set by
+ * the user, otherwise it will default to _draft_.
+ * */
 struct ProcessContext {
     char *currentFilePath;
     char *outPath;
@@ -31,23 +48,35 @@ struct ProcessContext {
     enum ProcessContextStatus status;
 };
 
+/* *
+ * ProjectState contians all the context needed for the program to process a 
+ * project. It contains the above FileIterator and ProcessContext to keep track
+ * of the program's place in both index and project files. It also contains a
+ * handler function that is determined based on the processing mode chosen by
+ * the user as well as a status to identify if any errors occur during 
+ * processing. 
+ * */
 struct ProjectState {
-    struct Arguments args;
     struct ProcessContext context;
     struct FileIterator iter;
     enum FileHandlerStatus (*handlerFunction)(struct ProcessContext *context);
     enum ProjectStateStatus status;
 };
 
-enum IndexStateStatus appendIndexState(struct FileIterator *iter,
-                                       const char *indexFilePath);
-struct IndexState *popIndexState(struct FileIterator *iter);
-enum FileHandlerStatus handleInit(struct ProcessContext *context);
-enum FileHandlerStatus handleCheck(struct ProcessContext *context);
-enum FileHandlerStatus handleList(struct ProcessContext *context);
-enum FileHandlerStatus handleCollate(struct ProcessContext *context);
-enum FileIteratorStatus getNextFile(struct FileIterator *iter,
-                                    struct ProcessContext *context);
+/* *
+ * Initializes state based on arguments passed by the user. Iterates through 
+ * index files, processing project files in the order they appear in
+ * the index files.
+ *
+ * @param args  Command line arguments included when the program is executed.
+ *
+ * @return 0 if process completes without and errors.
+ *         -1 if any error occurs during the process including:
+ *             - state intitialization
+ *             - index file traversal
+ *             - project file traversal/processing
+ *             - output writing
+ * */
 int processProject(struct Arguments *args);
 
 #endif

--- a/src/reporting.c
+++ b/src/reporting.c
@@ -16,6 +16,8 @@ static const char *fileOpStr(enum FileOperation op) {
         return "reading";
     case FILE_OP_WRITE:
         return "writing";
+    case FILE_OP_JOIN:
+        return "joining";
     case PATH_OP_VALIDATE:
         return "validating path inputs";
     case PATH_OP_COMPONENT:

--- a/src/reporting.h
+++ b/src/reporting.h
@@ -3,7 +3,24 @@
 
 #include "errors.h"
 
+/* *
+ * Reports errors specific to file operations to stderr. Includes system errno
+ * message when available.
+ *
+ * @param  op    Type of file operation that failed
+ * @param  path  Path to file that caused error, or descriptive string if no path
+ * */
 void reportFileError(enum FileOperation op, const char *path);
+
+/* *
+ * Reports a process error to stderr with detailed context. Includes operation
+ * type, relevant path, and specific error details. Also includes system errno
+ * message when available.
+ *
+ * @param  op       Type of process operation that failed
+ * @param  path     Path related to error, or NULL if no path involved
+ * @param  details  Specific error detail code describing what went wrong
+ * */
 void reportProcessError(enum ProcessOperation op,
                         const char *path,
                         enum ProcessErrorDetail details);

--- a/tests/check_test.sh
+++ b/tests/check_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# ASAN
+# ASAN_OPTIONS="detect_leaks=1"
+# export ASAN_OPTIONS
+
 # Test counter initialization
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -18,7 +22,6 @@ test_check_mode() {
     # Run colette in check mode and capture both output and status
     output=$($COLETTE --check "$project_dir" 2>&1)
     status=$?
-    
     # Verify the exit status matches what we expect
     if [ $status -eq $expected_status ]; then
         echo -e "${GREEN}✓ Exit status correct ($status)${NC}"
@@ -114,6 +117,13 @@ setup_filesystem_edge_cases() {
     echo "$long_name" > "$base_dir/long_names/.index"
     touch "$base_dir/long_names/$long_name"
     
+    # === Too long names test setup ===
+    mkdir -p "$base_dir/too_long_names"
+    # Create a filename that is over 255 characters
+    local too_long_name=$(printf 'a%.0s' {1..254})".md"
+    echo "$too_long_name" > "$base_dir/too_long_names/.index"
+    # touch "$base_dir/too_long_names/$too_long_name"
+
     # === Permission test setup ===
     mkdir -p "$base_dir/permissions/readonly_dir"
     mkdir -p "$base_dir/permissions/noexec_dir"
@@ -287,6 +297,10 @@ test_check_mode "$TEST_DATA/edge_cases/special_names" 0 "Success" \
 # Test long name handling
 test_check_mode "$TEST_DATA/edge_cases/long_names" 0 "Success" \
     "Project with maximum length filenames"
+
+# Test too long name handling
+test_check_mode "$TEST_DATA/edge_cases/too_long_names" 1 "Error joining extension joining" \
+    "Project with filenames exceeding maximum length"
 
 # Test permission handling
 test_check_mode "$TEST_DATA/edge_cases/permissions/readonly_dir" 0 "Success" \

--- a/tests/collate_test.sh
+++ b/tests/collate_test.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+
+# Initialize test counters (required by run_tests.sh)
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Lorem ipsum text for longer files
+LOREM="Lorem ipsum odor amet, consectetuer adipiscing elit. Lectus viverra habitant vulputate; suspendisse dolor nulla. Potenti ullamcorper etiam faucibus blandit at. Maximus venenatis ultrices proin integer sapien magna. Dictumst dolor pulvinar commodo consequat integer posuere. Commodo cursus justo ullamcorper sagittis varius vel ut. Himenaeos porta facilisi montes iaculis aliquam augue placerat lobortis. Fermentum elementum in maecenas pulvinar facilisis leo orci. Ante rhoncus congue mi nibh himenaeos torquent." 
+
+# Test helper function for collate mode
+test_collate() {
+    local project_dir="$1"
+    local expected_status="${2:-0}"  # Default to 0 if not provided
+    local expected_content="$3"
+    local test_name="$4"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -e "\n${YELLOW}Test $TESTS_RUN: $test_name${NC}"
+    
+    # Run colette in collate mode
+    output=$($COLETTE "$project_dir" 2>&1)
+    status=$?
+    
+    # First check if the status matches expected
+    if [ $status -eq $expected_status ]; then
+        echo -e "${GREEN}✓ Exit status correct ($status)${NC}"
+        status_passed=true
+    else
+        echo -e "${RED}✗ Expected status $expected_status, got $status${NC}"
+        status_passed=false
+    fi
+    
+    # Only check content if we expect success
+    if [ $expected_status -eq 0 ]; then
+        # Read the output file content
+        content=$(cat "$project_dir/_draft_.md")
+        
+        # Compare with expected content
+        if [ "$content" = "$expected_content" ]; then
+            echo -e "${GREEN}✓ Content matches expected${NC}"
+            output_passed=true
+        else
+            echo -e "${RED}✗ Content mismatch${NC}"
+            echo -e "${RED}Expected:${NC}\n$expected_content"
+            echo -e "${RED}Got:${NC}\n$content"
+            output_passed=false
+        fi
+    else
+        # For error cases, we consider output check passed if status was correct
+        output_passed=$status_passed
+    fi
+    
+    # Update test counts
+    if [ "$status_passed" = true ] && [ "$output_passed" = true ]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+test_collate_length() {
+    local project_dir="$1"
+    local test_name="$2"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -e "\n${YELLOW}Test $TESTS_RUN: $test_name${NC}"
+    
+    # Run colette in collate mode
+    output=$($COLETTE "$project_dir" 2>&1)
+    status=$?
+    
+    if [ $status -eq 0 ]; then
+        # Get the actual size of output file
+        local actual_size=$(stat -f %z "$project_dir/_draft_.md")
+        # Get sizes of input files
+        local large_size=$(stat -f %z "$project_dir/large_file.md")
+        local small_size=$(stat -f %z "$project_dir/small_file.md")
+        
+        # Add 2 for the newline after each file
+        local expected_size=$((large_size + small_size + 2))
+        
+        if [ "$actual_size" -eq "$expected_size" ]; then
+            echo -e "${GREEN}✓ File size matches expected ($actual_size bytes)${NC}"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        else
+            echo -e "${RED}✗ Size mismatch${NC}"
+            echo -e "${RED}Expected: $expected_size bytes${NC}"
+            echo -e "${RED}Got: $actual_size bytes${NC}"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+        fi
+    else
+        echo -e "${RED}✗ Collation failed with status $status${NC}"
+        echo -e "${RED}Output: $output${NC}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Set up simple project structure
+setup_simple_project() {
+    local dir="$TEST_DATA/simple_project"
+    mkdir -p "$dir"
+    
+    # Create root index
+    echo "chapter1.md" > "$dir/.index"
+    echo "chapter2.md" >> "$dir/.index"
+    
+    # Create content files
+    echo "Chapter 1 content" > "$dir/chapter1.md"
+    echo "Chapter 2 content" > "$dir/chapter2.md"
+}
+
+# Set up nested project structure
+setup_nested_project() {
+    local dir="$TEST_DATA/nested_project"
+    mkdir -p "$dir/part1/chapter1"
+    
+    # Create root index
+    echo "part1" > "$dir/.index"
+    
+    # Create part1 index
+    echo "chapter1" > "$dir/part1/.index"
+    
+    # Create chapter1 index
+    echo "scene1.md" > "$dir/part1/chapter1/.index"
+    echo "scene2.md" >> "$dir/part1/chapter1/.index"
+    
+    # Create content files
+    echo "Scene 1 content" > "$dir/part1/chapter1/scene1.md"
+    echo "Scene 2 content" > "$dir/part1/chapter1/scene2.md"
+}
+
+# Set up project with long files
+setup_large_file_project() {
+    local dir="$TEST_DATA/large_file_project"
+    mkdir -p "$dir"
+    
+    # Create root index
+    echo "large_file.md" > "$dir/.index"
+    echo "small_file.md" >> "$dir/.index"
+    
+    # Create small file for comparison
+    echo "Small file content" > "$dir/small_file.md"
+    
+    # Generate large file content (>8192 bytes)
+    for i in {1..101}; do
+        echo "$LOREM" >> "$dir/large_file.md"
+    done
+}
+
+# Set up project with edge cases
+setup_edge_cases() {
+    local dir="$TEST_DATA/edge_cases"
+    mkdir -p "$dir"
+    
+    # Create root index with empty lines and comments
+    cat > "$dir/.index" << EOL
+# Introduction
+intro.md
+
+# Main content
+content.md
+EOL
+    
+    # Create content files
+    echo "Introduction with special chars: áéíóú" > "$dir/intro.md"
+    printf "Content with various newlines.\n\n\nMultiple empty lines.\n" > "$dir/content.md"
+}
+
+# Set up error case projects
+setup_error_cases() {
+    local dir="$TEST_DATA/error_cases"
+    mkdir -p "$dir/no_permission" "$dir/missing_file"
+    
+    # Project with permission issues
+    echo "valid_file.md" > "$dir/no_permission/.index"
+    echo "file.md" >> "$dir/no_permission/.index"
+    echo "Valid content" > "$dir/no_permission/valid_file.md"
+    echo "Content that will be unreadable" > "$dir/no_permission/file.md"
+    chmod 000 "$dir/no_permission/file.md"
+    
+    # Project with missing files
+    echo "valid_file.md" > "$dir/missing_file/.index"
+    echo "nonexistent.md" >> "$dir/missing_file/.index"
+    echo "Valid content" > "$dir/missing_file/valid_file.md"
+}
+
+# Run the tests
+setup_simple_project
+test_collate "$TEST_DATA/simple_project" 0 \
+    "Chapter 1 content
+
+Chapter 2 content" \
+    "Simple project collation"
+
+setup_nested_project
+test_collate "$TEST_DATA/nested_project" 0 \
+    "Scene 1 content
+
+Scene 2 content" \
+    "Nested project collation"
+
+setup_large_file_project
+test_collate_length "$TEST_DATA/large_file_project" "Large file size test"
+
+setup_edge_cases
+test_collate "$TEST_DATA/edge_cases" 0 \
+    "Introduction with special chars: áéíóú
+
+Content with various newlines.
+
+
+Multiple empty lines." \
+    "Edge cases (special chars, varied newlines)"
+
+setup_error_cases
+# Test missing file error
+test_collate "$TEST_DATA/error_cases/missing_file" 1 \
+    "Valid content" \
+    "Missing file error handling"
+
+# Test permission error
+test_collate "$TEST_DATA/error_cases/no_permission" 1 \
+    "Valid content" \
+    "Permission error handling"
+
+# Clean up
+cleanup_test_projects() {
+    chmod 666 "$TEST_DATA/error_cases/no_permission/file.md"
+    rm -rf "$TEST_DATA/simple_project"
+    rm -rf "$TEST_DATA/nested_project"
+    rm -rf "$TEST_DATA/edge_cases"
+    rm -rf "$TEST_DATA/error_cases"
+}
+
+cleanup_test_projects

--- a/tests/run_memcheck.sh
+++ b/tests/run_memcheck.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Get absolute paths (using same pattern as your run_tests.sh)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_DATA="$SCRIPT_DIR/testdata"
+COLETTE="$PROJECT_ROOT/bin/colette"
+
+# ASAN/LSAN configuration for memory checking
+export ASAN_OPTIONS="detect_leaks=1:print_stats=1:halt_on_error=0:exitcode=0"
+export LSAN_OPTIONS="detect_leaks=1:print_suppressions=0:max_leaks=0"
+
+# Set up test directory structure
+echo "Setting up test directory..."
+mkdir -p "$TEST_DATA/memcheck/valid"
+mkdir -p "$TEST_DATA/memcheck/nested"
+
+# Create test files
+echo "chapter1.md" > "$TEST_DATA/memcheck/valid/.index"
+echo "Chapter 1" > "$TEST_DATA/memcheck/valid/chapter1.md"
+
+echo "chapter1" > "$TEST_DATA/memcheck/nested/.index"
+mkdir -p "$TEST_DATA/memcheck/nested/chapter1"
+echo "scene1.md" > "$TEST_DATA/memcheck/nested/chapter1/.index"
+echo "Scene 1" > "$TEST_DATA/memcheck/nested/chapter1/scene1.md"
+
+# Run memory checks for each mode
+echo -e "\nTesting check mode..."
+$COLETTE --check "$TEST_DATA/memcheck/valid"
+
+echo -e "\nTesting collate mode..."
+$COLETTE "$TEST_DATA/memcheck/valid"
+
+# echo -e "\nTesting init mode..."
+# $COLETTE --init "$TEST_DATA/memcheck/nested"
+
+# Clean up
+echo -e "\nCleaning up..."
+rm -rf "$TEST_DATA/memcheck"
+
+echo -e "\nMemory check complete."

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,7 +3,6 @@
 # Get absolute paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-# export LSAN_OPTIONS="detect_leaks=1:verbosity=2:report_objects=1:max_leaks=0"
 export TEST_DATA="$SCRIPT_DIR/testdata"
 export COLETTE="$PROJECT_ROOT/bin/colette"
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,6 +3,7 @@
 # Get absolute paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# export LSAN_OPTIONS="detect_leaks=1:verbosity=2:report_objects=1:max_leaks=0"
 export TEST_DATA="$SCRIPT_DIR/testdata"
 export COLETTE="$PROJECT_ROOT/bin/colette"
 


### PR DESCRIPTION
This pull request implements Colette's basic collation functionality, updates the Makefile, and tests. It also includes added inline documentation, some light refactoring, and memory management fixes. Later PRs will add more configurability.

### Changes
- Updates Makefile for running tests and memory leak/address sanitization
- Adds function descriptions and other inline documentation for structs in header files
- Makes all non-included functions static
- Simplifies return types for functions that only succeed or fail
- Adds error handling improvements
- Implements `handleCollate` handler function 

### Collate mode
Collate mode is actually the only thing this program was originally meant to do and as I started implementing that I began to realize just how much is involved in what seemed like a pretty simple operation and also the scope of the project began to expand. Collate mode creates an output file and then writes all the project files into the output file in the order they are listed in the index files. The output file can then be converted to another format via pandoc for printing, typesetting, or distribution.

The whole point of collate mode and colette as a whole is to allow a writer who prefers working in Vim or in the terminal to compose a project modularly and non-linearly and compile it down into a structured document. It's heavily inspired by the module systems of programming languages and the writing program Scrivener. The project structure is defined by index files which list project files and subdirectories in their desired order. The idea is that the project can be easily re-ordered and re-composed just by editing the index files rather than sequentially naming the project files or moving pieces of text around in a single large document. 