### PR TITLE
Feat/init -- initialize project with .index files and update existing .index files with new project files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ SCRIPT_DIR = tests
 
 # Find all source files
 SOURCES = $(wildcard $(SRC_DIR)/*.c)
-OBJECTS = $(SOURCES:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
+OBJECTS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SOURCES))
 EXECUTABLE = $(BIN_DIR)/colette
 
 # Build targets

--- a/README.md
+++ b/README.md
@@ -2,34 +2,58 @@
 
 A command-line tool for organizing and collating text files in writing projects.
 
+
+## Contents
+
+- [Overview](#overview)
+- [Status](#status)
+- [Usage](usage)
+- [Project Structure](#project-structure)
+- [Installation](#installation)
+- [Features](#features-planned)
+- [Requirements](#requirements)
+- [License](#license)
+
+
 ## Overview
 
-Colette helps writers manage multi-file writing projects by providing tools to organize and combine text files based on index files that define the desired order. It's particularly useful for writers who break their work into smaller, manageable files but need to easily combine them for review or export.
+Colette helps writers manage multi-file writing projects by providing means to organize and combine text files based on index files that define the desired order. It's particularly useful for writers who break their work into smaller, manageable files but need to easily combine them for review or export.
+
+Default behavior, with no flags, will assume a project is initialized and will traverse the specified directory and its subdirectories, collating each project file into a single "draft" using the index files to determine the order project files are processed.
+
+Initialize a project with the `--init` flag. This will traverse the project and generate index files in every directory. The index files will mirror the system file structure, with each project file on its own line. The order of the text in the collated output is determined by the order specified in these index files. Rearrange the file names in the index files to structure the project. This way, project structure is decoupled from the computer's file system. Project file and directory names can be purely descriptive of scenes and chapters without having to worry about naming them sequentially. No more renaming every file when you insert a new scene!
+
+Use the `--check` flag to avoid generating or overwriting the output file. Used in tandem with `--init`, it will generate index files without needlessly creating an output. Used on its own, it will verify the project structure is valid for colette to run.
+
+The `--title` flag allows you to specify the name of the output file. This is helpful for generating multiple drafts.
+
 
 ## Status
 
 ⚠️ **Early Development** - Core features are under active development
 
-## Features (Planned)
+Colette currently assumes projects consist of markdown and txt files. Mixing file types will affect the order that project files are added to index files. It is recommended to stick with one or the other. The output file will always be `.md`.
 
-- Recursive file collation based on index files
-- Automatic project initialization
-- Project structure validation
-- Support for infinitely nested scene structures
-- Markdown support (other markup languages planned)
 
 ## Usage
 
 ```bash
-# Initialize a writing project and generate index files
-colette --init path/to/project
-
-# Collate files in a directory according to its index
+# Recursively collate files in a directory in order specified by index files
 colette path/to/project
 
-# Validate project structure
+# Initialize a writing project, generate index files and output file
+colette --init path/to/project
+
+# Validate project structure without generating an output file
 colette --check path/to/project
+
+# Name the output file
+colette --title custom_title path/to/project
+
+# Initialize project without generating an output file
+colette -ic path/to/project
 ```
+
 
 ## Project Structure
 
@@ -52,9 +76,23 @@ project/
 
 Files or directories prefixed with `_` are ignored during collation.
 
+
 ## Installation
 
 Currently requires manual compilation. Installation instructions coming soon.
+
+Clone this repository, `cd` into the root directory and run `make release`. Copy binary into `~/bin/` or preferred directory in your PATH.
+
+
+## Features (Planned)
+
+- [x] Recursive file collation based on index files
+- [x] Automatic project initialization
+- [x] Project structure validation
+- [ ] Symlink list alternative to single collated file
+- [ ] Support for infinitely nested scene structures
+- [x] Markdown support (other markup languages planned)
+
 
 ## Requirements
 
@@ -62,7 +100,8 @@ Currently requires manual compilation. Installation instructions coming soon.
 - C compiler (gcc recommended)
 - make
 
+
 ## License
 
-[License details to be determined]
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/zacharyarney/colette/blob/feat/init/LICENSE) file for details.
 

--- a/src/args.h
+++ b/src/args.h
@@ -3,9 +3,9 @@
 
 #include <stdbool.h>
 
-/**
+/* *
  * Possible error states when parsing command line arguments.
- */
+ * */
 enum ArgError {
     ARG_SUCCESS,              // Arguments parsed successfully
     ARG_MISSING_DIR,          // No directory argument provided
@@ -22,9 +22,9 @@ enum ArgError {
     ARG_USAGE_MSG,            // Show usage message
 };
 
-/**
+/* *
  * Operating modes that determine if and how files are processed.
- */
+ * */
 enum ProcessMode {
     MODE_COLLATE,
     MODE_LIST,

--- a/src/constants.h
+++ b/src/constants.h
@@ -2,6 +2,13 @@
 #define CONSTANTS_H
 
 /* *
+ * Enforce C99 standard when compiling
+ * */
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L
+#error "colette requires a C99-compatible compiler or newer"
+#endif
+
+/* *
  * Common system page size. Should be large enough buffer for most paths
  * */
 #define COLETTE_PATH_BUF_SIZE 4096

--- a/src/files.c
+++ b/src/files.c
@@ -65,6 +65,12 @@ bool isIncluded(const char *fileName) {
     if (fileName == NULL || fileName[0] == '\0') {
         return false;
     }
+    /* *
+     * TODO: Handle comments better ya dingus 
+     * */
+    if (fileName[0] == '#') {
+        return false;
+    }
 
     return (fileName[0] != '.' && fileName[0] != '_');
 }

--- a/src/files.c
+++ b/src/files.c
@@ -29,10 +29,43 @@ static const char **getSupportedExtensions(void) {
 //     return count;
 // }
 
+bool isDir(const char *path) {
+    if (!path || path[0] == '\0') {
+        return false;
+    }
+
+    struct stat statBuf;
+    if (lstat(path, &statBuf) == 0) {
+        if (S_ISDIR(statBuf.st_mode)) {
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
+bool isReg(const char *path) {
+    if (!path || path[0] == '\0') {
+        return false;
+    }
+
+    struct stat statBuf;
+    if (lstat(path, &statBuf) == 0) {
+        if (S_ISREG(statBuf.st_mode)) {
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
 bool isIncluded(const char *fileName) {
     if (fileName == NULL || fileName[0] == '\0') {
         return false;
     }
+
     return (fileName[0] != '.' && fileName[0] != '_');
 }
 
@@ -81,6 +114,7 @@ resolveFile(char *buffer, size_t buffSize, const char *path) {
 
     return RESOLVE_NOT_FOUND;
 }
+
 int getBasename(char *buffer, const char *path, size_t size) {
     if (!buffer || !path || size == 0) {
         return -1;

--- a/src/files.h
+++ b/src/files.h
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
-/**
+/* *
  * Determines if a file or directory is to be included in the final output.
  *
  * Hidden files are denoted with a '.' or '_' prefix. User-created files are to
@@ -22,8 +22,30 @@
  * @return  bool
  *          true      if file should be included in finale output
  *          false     if file should be ignored
- **/
+ * */
 bool isIncluded(const char *fileName);
+
+/* *
+ * Determines if a path is a directory.
+ *
+ * @param   path    Name of path to be checked
+ *
+ * @return  bool
+ *          true    if path is a directory
+ *          false   if path is not a directory
+ * */
+bool isDir(const char *path);
+
+/* *
+ * Determines if a path is a regular file.
+ *
+ * @param   path    Name of path to be checked
+ *
+ * @return  bool
+ *          true    if path is a directory
+ *          false   if path is not a directory
+ * */
+bool isReg(const char *path);
 
 /* *
  * Distinguishes between directories and regular files and symbolic links.

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,227 @@
+#include "constants.h"
+#include "errors.h"
+#include "files.h"
+#include "init.h"
+#include "reporting.h"
+#include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+static bool entryExists(FILE *indexFile, const char *entryName) {
+    if (!indexFile || !entryName) {
+        return false;
+    }
+
+    char lineBuf[COLETTE_NAME_BUF_SIZE];
+    bool exists = false;
+
+    while (fgets(lineBuf, sizeof(lineBuf), indexFile)) {
+        size_t lineLen = strlen(lineBuf);
+        if (lineLen == 0 || lineBuf[0] == '#') {
+            continue;
+        }
+
+        if (lineBuf[lineLen - 1] == '\n') {
+            lineBuf[lineLen - 1] = '\0';
+            lineLen--;
+        }
+
+        if (strcmp(lineBuf, entryName) == 0) {
+            exists = true;
+            break;
+        }
+    }
+
+    return exists;
+}
+
+static int addToIndexFile(FILE *indexFile, const char *entryName) {
+    if (!indexFile || !entryName) {
+        return -1;
+    }
+
+    long curPos = ftell(indexFile);
+    rewind(indexFile);
+
+    if (!entryExists(indexFile, entryName)) {
+        fseek(indexFile, 0, SEEK_END);
+
+        // Add newline to end of file if necessary
+        if (ftell(indexFile) > 0) {
+            fseek(indexFile, -1, SEEK_END);
+            char lastChar;
+            if (fread(&lastChar, 1, 1, indexFile) == 1 && lastChar != '\n') {
+                fprintf(indexFile, "\n");
+            }
+
+            fseek(indexFile, 0, SEEK_END);
+        }
+
+        fprintf(indexFile, "%s\n", entryName);
+    } else {
+        fseek(indexFile, curPos, SEEK_SET);
+    }
+
+    return 0;
+}
+
+static FILE *openOrCreateIndexFile(const char *dirPath) {
+    if (!dirPath) {
+        return NULL;
+    }
+
+    char indexFilePath[COLETTE_PATH_BUF_SIZE];
+    if (joinPath(indexFilePath, sizeof(indexFilePath), dirPath, ".index") !=
+        0) {
+        reportProcessError(
+            PROCESS_OP_HANDLE_INIT, dirPath, PROC_ERR_PATH_TOO_LONG);
+        return NULL;
+    }
+
+    if (isReg(indexFilePath)) {
+        errno = 0;
+        FILE *indexFile = fopen(indexFilePath, "a+");
+        if (!indexFile) {
+            reportProcessError(
+                PROCESS_OP_HANDLE_INIT, indexFilePath, PROC_ERR_OPEN_FILE);
+            return NULL;
+        }
+
+        rewind(indexFile); // move to beginning of index file
+        return indexFile;
+    }
+
+    errno = 0;
+    FILE *indexFile = fopen(indexFilePath, "w+");
+    if (!indexFile) {
+        reportProcessError(
+            PROCESS_OP_HANDLE_INIT, indexFilePath, PROC_ERR_OPEN_FILE);
+        return NULL;
+    }
+
+    return indexFile;
+}
+
+int enqueue(struct InitQueue **queue, const char *dirPath) {
+    if (!queue) {
+        return -1;
+    }
+
+    if (!dirPath) {
+        return -1;
+    }
+
+    struct InitQueue *newNode = malloc(sizeof(struct InitQueue));
+    if (!newNode) {
+        return -1;
+    }
+
+    size_t dirPathLen = strlen(dirPath) + 1;
+    char *pathCopy = malloc(dirPathLen);
+    if (!pathCopy) {
+        free(newNode);
+        return -1;
+    }
+    memcpy(pathCopy, dirPath, dirPathLen);
+
+    newNode->dirPath = pathCopy;
+    newNode->next = NULL;
+
+    if (!*queue) {
+        *queue = newNode;
+    } else {
+        struct InitQueue *cur = *queue;
+        while (cur->next) {
+            cur = cur->next;
+        }
+        cur->next = newNode;
+    }
+
+    return 0;
+}
+
+int dequeue(struct InitQueue **queue, char *outPath, size_t outPathLen) {
+    if (!*queue) {
+        return -1;
+    }
+
+    struct InitQueue *oldHead = *queue;
+
+    size_t pathLen = strlen(oldHead->dirPath) + 1;
+    if (pathLen > outPathLen) {
+        reportProcessError(
+            PROCESS_OP_HANDLE_INIT, oldHead->dirPath, PROC_ERR_PATH_TOO_LONG);
+        return -1;
+    }
+    memcpy(outPath, oldHead->dirPath, pathLen);
+
+    *queue = oldHead->next;
+
+    free(oldHead->dirPath);
+    free(oldHead);
+
+    return 0;
+}
+
+int handleInit(char *rootDir) {
+    if (!rootDir) {
+        return -1;
+    }
+
+    int errorCount = 0;
+    struct InitQueue *queue = NULL;
+
+    if (enqueue(&queue, rootDir) != 0) {
+        return -1;
+    }
+
+    while (queue) {
+        char curDir[COLETTE_PATH_BUF_SIZE];
+
+        if (dequeue(&queue, curDir, sizeof(curDir)) != 0) {
+            break;
+        }
+
+        DIR *dir = opendir(curDir);
+        if (!dir) {
+            continue;
+        }
+
+        FILE *indexFile = openOrCreateIndexFile(curDir);
+        if (!indexFile) {
+            closedir(dir);
+            reportProcessError(
+                PROCESS_OP_HANDLE_INIT, curDir, PROC_ERR_INDEX_MISSING);
+            errorCount++;
+            continue; // should this continue or break?
+        }
+
+        struct dirent *entry;
+        while ((entry = readdir(dir))) {
+            if (!isIncluded(entry->d_name)) {
+                continue;
+            }
+
+            char fullPath[COLETTE_PATH_BUF_SIZE];
+            joinPath(fullPath, sizeof(fullPath), curDir, entry->d_name);
+
+            if (isReg(fullPath)) {
+                addToIndexFile(indexFile, entry->d_name);
+            } else if (isDir(fullPath)) {
+                addToIndexFile(indexFile, entry->d_name);
+                enqueue(&queue, fullPath);
+            }
+        }
+
+        fclose(indexFile);
+        closedir(dir);
+    }
+
+    while (queue) {
+        char tmpPath[COLETTE_PATH_BUF_SIZE];
+        dequeue(&queue, tmpPath, sizeof(tmpPath));
+    }
+
+    return errorCount > 0 ? -1 : 0;
+}

--- a/src/init.h
+++ b/src/init.h
@@ -1,0 +1,15 @@
+#ifndef INIT_H
+#define INIT_H
+
+#include <stdlib.h>
+
+struct InitQueue {
+    char *dirPath;
+    struct InitQueue *next;
+};
+
+int enqueue(struct InitQueue **queue, const char *dirPath);
+int dequeue(struct InitQueue **queue, char *outPath, size_t outPathLen);
+int handleInit(char *rootDir);
+
+#endif

--- a/src/process.c
+++ b/src/process.c
@@ -1,6 +1,7 @@
 #include "constants.h"
 #include "errors.h"
 #include "files.h"
+#include "init.h"
 #include "process.h"
 #include "reporting.h"
 #include <errno.h>
@@ -595,6 +596,11 @@ int processProject(struct Arguments *args) {
         return -1;
     }
 
+    if (args->initMode) {
+        if (handleInit(args->directory) != 0) {
+            return -1;
+        }
+    }
     if (appendIndexState(&state.iter, args->directory) != 0) {
         freeProjectState(&state);
         return -1;
@@ -607,6 +613,9 @@ int processProject(struct Arguments *args) {
         freeProjectState(&state);
         return -1;
     }
+    if (args->initMode) {
+        handleInit(args->directory);
+    }
 
     while ((state.iter.status = getNextFile(&state.iter, &state.context)) !=
            ITER_END) {
@@ -614,9 +623,7 @@ int processProject(struct Arguments *args) {
             freeProjectState(&state);
             return -1;
         }
-        if (args->initMode) {
-            // handleInit
-        }
+
         if (state.handlerFunction) {
             enum FileHandlerStatus handlerStatus =
                 state.handlerFunction(&state.context);

--- a/tests/init_ordering_test.sh
+++ b/tests/init_ordering_test.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# New tests focused on preserving pre-existing .index order and appending new files alphabetically.
+
+# Local counters (aggregated by run_tests.sh)
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Helpers
+_pass() { echo -e "${GREEN}PASS${NC}"; TESTS_PASSED=$((TESTS_PASSED+1)); }
+_fail() { echo -e "${RED}FAIL${NC}"; TESTS_FAILED=$((TESTS_FAILED+1)); }
+
+# Assert index file content equals expected (exact match)
+assert_index_equals() {
+  local index_path="$1"
+  local expected="$2"
+  # Trim possible trailing whitespace differences by using printf as the ground truth
+  local tmp_expected="$(mktemp)"
+  printf "%s" "$expected" > "$tmp_expected"
+  if diff -u "$tmp_expected" "$index_path" > /dev/null; then
+    _pass
+  else
+    echo "Expected:"
+    cat "$tmp_expected" | sed 's/^/  /'
+    echo "Actual:"
+    cat "$index_path" | sed 's/^/  /'
+    _fail
+  fi
+  rm -f "$tmp_expected"
+}
+
+# Case 1: Pre-existing .index with custom (non-alpha) order is preserved;
+#         new files are appended in alphabetical order.
+preexisting_index_preserved_and_new_appended_sorted() {
+  TESTS_RUN=$((TESTS_RUN+1))
+  echo -e "\n${YELLOW}Test $TESTS_RUN: Pre-existing order preserved; new files appended alphabetically${NC}"
+
+  local dir="$TEST_DATA/preexisting_order_case"
+  rm -rf "$dir"; mkdir -p "$dir"
+
+  # Files present
+  touch "$dir/a.txt" "$dir/b.txt" "$dir/c.txt" "$dir/d.txt"
+
+  # User-chosen custom order: deliberately non-alphabetical
+  # Note: final newline matters to avoid auto-newline behavior differences.
+  printf "c.txt\na.txt\n" > "$dir/.index"
+
+  # Run init
+  "$COLETTE" --init "$dir" >/dev/null 2>&1
+  local status=$?
+
+  if [ $status -ne 0 ]; then
+    echo "Expected exit status 0, got $status"; _fail; return
+  fi
+
+  # Expect existing lines preserved in their original order,
+  # and unseen files [b.txt, d.txt] appended in alpha order.
+  local expected="c.txt
+a.txt
+b.txt
+d.txt
+"
+  assert_index_equals "$dir/.index" "$expected"
+}
+
+# Case 2: Idempotency — running init again does not duplicate entries or reorder anything.
+idempotent_second_run_no_changes() {
+  TESTS_RUN=$((TESTS_RUN+1))
+  echo -e "\n${YELLOW}Test $TESTS_RUN: Idempotent second run — no reordering or duplication${NC}"
+
+  local dir="$TEST_DATA/idempotent_case"
+  rm -rf "$dir"; mkdir -p "$dir"
+  touch "$dir/a.txt" "$dir/b.txt" "$dir/c.txt"
+  printf "b.txt\na.txt\nc.txt\n" > "$dir/.index"
+
+  "$COLETTE" --init "$dir" >/dev/null 2>&1
+  local status1=$?
+  "$COLETTE" --init "$dir" >/dev/null 2>&1
+  local status2=$?
+
+  if [ $status1 -ne 0 ] || [ $status2 -ne 0 ]; then
+    echo "Expected both runs to exit 0, got $status1 and $status2"; _fail; return
+  fi
+
+  local expected="b.txt
+a.txt
+c.txt
+"
+  assert_index_equals "$dir/.index" "$expected"
+}
+
+# Case 3: New files with tricky names (spaces, punctuation) get appended in correct alpha order.
+append_tricky_names_sorted() {
+  TESTS_RUN=$((TESTS_RUN+1))
+  echo -e "\n${YELLOW}Test $TESTS_RUN: Append tricky names — sorted order for new entries${NC}"
+
+  local dir="$TEST_DATA/tricky_names_case"
+  rm -rf "$dir"; mkdir -p "$dir"
+  # Preexisting set & order
+  touch "$dir/alpha.txt" "$dir/zulu.txt"
+  printf "zulu.txt\nalpha.txt\n" > "$dir/.index"
+
+  # Add tricky filenames
+  touch "$dir/Bravo.md" "$dir/bravo2.md" "$dir/ space.md" "$dir/!bang.txt"
+
+  "$COLETTE" --init "$dir" >/dev/null 2>&1
+  local status=$?
+  if [ $status -ne 0 ]; then
+    echo "Expected exit status 0, got $status"; _fail; return
+  fi
+
+  # scandir + alphasort is locale-dependent but usually orders this roughly as:
+  # " !bang.txt", " space.md", "Bravo.md", "alpha.txt", "bravo2.md", "zulu.txt"
+  # However, our logic *appends only unseen entries* in the order returned by alphasort.
+  # So expected is: keep preexisting lines in their order, then unseen sorted:
+  # zulu.txt
+  # alpha.txt
+  # !bang.txt
+  #  space.md
+  # Bravo.md
+  # bravo2.md
+  # (Note: filename with a leading space is intentional.)
+
+  local expected="zulu.txt
+alpha.txt
+ space.md
+!bang.txt
+Bravo.md
+bravo2.md
+"
+  assert_index_equals "$dir/.index" "$expected"
+}
+
+# Case 4: Nested directories — each directory gets/keeps its own .index; subdirs added and traversed.
+nested_directories_preserve_and_append() {
+  TESTS_RUN=$((TESTS_RUN+1))
+  echo -e "\n${YELLOW}Test $TESTS_RUN: Nested directories — preserve parent order and append children${NC}"
+
+  local root="$TEST_DATA/nested_case"
+  local ch1="$root/ch1"
+  local ch2="$root/ch2"
+  rm -rf "$root"; mkdir -p "$ch1" "$ch2"
+
+  # Prepare files
+  touch "$root/r1.txt" "$root/r2.txt"
+  touch "$ch1/a.txt" "$ch1/c.txt"
+  touch "$ch2/b.txt"
+
+  # Parent has custom order and references to subdirs will be appended by init
+  printf "r2.txt\nr1.txt\n" > "$root/.index"
+  # Child ch1 existing order non-alpha
+  printf "c.txt\na.txt\n" > "$ch1/.index"
+  # ch2 has no .index yet
+
+  "$COLETTE" --init "$root" >/dev/null 2>&1
+  local status=$?
+  if [ $status -ne 0 ]; then
+    echo "Expected exit status 0, got $status"; _fail; return
+  fi
+
+  # root: r2.txt, r1.txt (preserved), then 'ch1', 'ch2' appended in alpha order
+  local expected_root="r2.txt
+r1.txt
+ch1
+ch2
+"
+  assert_index_equals "$root/.index" "$expected_root"
+
+  # ch1: keep existing order, and no new files (since only a.txt, c.txt existed)
+  local expected_ch1="c.txt
+a.txt
+"
+  assert_index_equals "$ch1/.index" "$expected_ch1"
+
+  # ch2: new index created, listing 'b.txt'
+  local expected_ch2="b.txt
+"
+  assert_index_equals "$ch2/.index" "$expected_ch2"
+}
+
+# Execute cases
+preexisting_index_preserved_and_new_appended_sorted
+idempotent_second_run_no_changes
+append_tricky_names_sorted
+nested_directories_preserve_and_append
+
+# Print suite summary (consumed by run_tests.sh)
+echo -e "\n${YELLOW}init_ordering_test.sh summary:${NC}"
+echo "  Tests run:    $TESTS_RUN"
+echo "  Tests passed: $TESTS_PASSED"
+echo "  Tests failed: $TESTS_FAILED"

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# Initialize test counters (required by run_tests.sh)
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test helper function for init mode
+test_init() {
+    local project_dir="$1"
+    local expected_status="$2"
+    local test_name="$3"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -e "\n${YELLOW}Test $TESTS_RUN: $test_name${NC}"
+    
+    # Run colette in init mode
+    output=$($COLETTE --init "$project_dir" 2>&1)
+    status=$?
+    
+    # Check exit status
+    if [ $status -eq $expected_status ]; then
+        echo -e "${GREEN}✓ Exit status correct ($status)${NC}"
+        status_passed=true
+    else
+        echo -e "${RED}✗ Expected status $expected_status, got $status${NC}"
+        status_passed=false
+    fi
+    
+    # For now, we consider a passed test if the status is correct
+    if [ "$status_passed" = true ]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Test helper for validating index content
+check_index_content() {
+    local index_file="$1"
+    local expected_content="$2" # Using literal newlines in string
+    local test_name="$3"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -e "\n${YELLOW}Test $TESTS_RUN: $test_name${NC}"
+    
+    if [ ! -f "$index_file" ]; then
+        echo -e "${RED}✗ Index file does not exist: $index_file${NC}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return
+    fi
+    
+    # Read the index file content, remove empty lines and comments, and normalize
+    content=$(grep -v "^$\|^#" "$index_file" | sort | tr -d '\r' | sed 's/[[:space:]]*$//')
+    # Normalize expected content the same way
+    sorted_expected=$(echo "$expected_content" | sort | tr -d '\r' | sed 's/[[:space:]]*$//')
+    
+    # For debugging
+    if [ "$content" != "$sorted_expected" ]; then
+        echo "Content (hex):" 
+        hexdump -C <<< "$content"
+        echo "Expected (hex):"
+        hexdump -C <<< "$sorted_expected"
+    fi
+    
+    if [ "$content" = "$sorted_expected" ]; then
+        echo -e "${GREEN}✓ Index content matches expected${NC}"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗ Index content mismatch${NC}"
+        echo -e "${RED}Expected:${NC}\n$sorted_expected"
+        echo -e "${RED}Got:${NC}\n$content"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Setup functions for test cases
+setup_empty_project() {
+    local dir="$TEST_DATA/empty_project"
+    mkdir -p "$dir"
+    # intentionally empty
+}
+
+setup_simple_project() {
+    local dir="$TEST_DATA/simple_project"
+    mkdir -p "$dir"
+    
+    # Create some content files
+    echo "Chapter 1 content" > "$dir/chapter1.md"
+    echo "Chapter 2 content" > "$dir/chapter2.md"
+    echo "Notes" > "$dir/_notes.md"  # Should be excluded
+}
+
+setup_nested_project() {
+    local dir="$TEST_DATA/nested_project"
+    mkdir -p "$dir/part1/chapter1"
+    mkdir -p "$dir/part1/chapter2"
+    mkdir -p "$dir/_drafts"  # Should be excluded
+    
+    # Create content files at different levels
+    echo "Introduction" > "$dir/intro.md"
+    echo "Chapter 1 Scene 1" > "$dir/part1/chapter1/scene1.md"
+    echo "Chapter 1 Scene 2" > "$dir/part1/chapter1/scene2.md"
+    echo "Chapter 2 Scene 1" > "$dir/part1/chapter2/scene1.md"
+    echo "Draft" > "$dir/_drafts/draft.md"  # Should be excluded
+}
+
+setup_special_names_project() {
+    local dir="$TEST_DATA/special_names"
+    mkdir -p "$dir"
+    
+    # Create files with special characters in names
+    touch "$dir/file with spaces.md"
+    touch "$dir/file-with-dashes.md"
+    touch "$dir/file_with_underscores.md"
+    touch "$dir/file.with.dots.md"
+    touch "$dir/file@with@special@chars.md"
+}
+
+setup_permissions_test() {
+    local dir="$TEST_DATA/permissions"
+    mkdir -p "$dir/readonly_dir"
+    mkdir -p "$dir/nowrite_dir"
+    
+    # Create content files
+    echo "Content" > "$dir/readonly_dir/file.md"
+    echo "Content" > "$dir/nowrite_dir/file.md"
+    
+    # Create empty index file first (for read-only test)
+    touch "$dir/nowrite_dir/.index"
+    
+    # Set permissions
+    chmod 555 "$dir/readonly_dir"  # read-only directory
+    chmod 444 "$dir/nowrite_dir/.index"  # read-only index file (no write permission)
+}
+
+# Run tests for empty project
+setup_empty_project
+test_init "$TEST_DATA/empty_project" 0 "Initialize empty project"
+check_index_content "$TEST_DATA/empty_project/.index" "" "Empty project index content"
+
+# Run tests for simple project
+setup_simple_project
+test_init "$TEST_DATA/simple_project" 0 "Initialize simple project"
+check_index_content "$TEST_DATA/simple_project/.index" "chapter1.md
+chapter2.md" "Simple project index content"
+
+# Run tests for nested project
+setup_nested_project
+test_init "$TEST_DATA/nested_project" 0 "Initialize nested project"
+check_index_content "$TEST_DATA/nested_project/.index" "intro.md
+part1" "Root index content in nested project"
+check_index_content "$TEST_DATA/nested_project/part1/.index" "chapter1
+chapter2" "Part1 index content in nested project"
+check_index_content "$TEST_DATA/nested_project/part1/chapter1/.index" "scene1.md
+scene2.md" "Chapter1 index content in nested project"
+check_index_content "$TEST_DATA/nested_project/part1/chapter2/.index" "scene1.md" "Chapter2 index content in nested project"
+
+# Run tests for special names
+setup_special_names_project
+test_init "$TEST_DATA/special_names" 0 "Initialize project with special filenames"
+check_index_content "$TEST_DATA/special_names/.index" "file with spaces.md
+file-with-dashes.md
+file.with.dots.md
+file@with@special@chars.md
+file_with_underscores.md" "Special names index content"
+
+# Run test for re-initialization
+# First initialize, then modify index, then re-initialize
+test_init "$TEST_DATA/simple_project" 0 "Re-initialize existing project"
+# Modify index to remove one file (use sed differently on MacOS vs Linux)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' '/chapter2.md/d' "$TEST_DATA/simple_project/.index"
+else
+    # Linux
+    sed -i '/chapter2.md/d' "$TEST_DATA/simple_project/.index"
+fi
+# Re-run initialization
+test_init "$TEST_DATA/simple_project" 0 "Re-initialize after index modification"
+check_index_content "$TEST_DATA/simple_project/.index" "chapter1.md
+chapter2.md" "Re-initialized index content"
+
+# Run tests for error conditions
+setup_permissions_test
+test_init "$TEST_DATA/permissions/readonly_dir" 1 "Initialize read-only directory"
+test_init "$TEST_DATA/permissions/nowrite_dir" 1 "Initialize directory with read-only index"
+
+# Clean up
+cleanup_test_projects() {
+    chmod -R 777 "$TEST_DATA/permissions" 2>/dev/null || true
+    rm -rf "$TEST_DATA/empty_project"
+    rm -rf "$TEST_DATA/simple_project"
+    rm -rf "$TEST_DATA/nested_project"
+    rm -rf "$TEST_DATA/special_names"
+    rm -rf "$TEST_DATA/permissions"
+}
+
+cleanup_test_projects

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,6 +6,9 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 export TEST_DATA="$SCRIPT_DIR/testdata"
 export COLETTE="$PROJECT_ROOT/bin/colette"
 
+# Set locale
+export LC_ALL=C LANG=C
+
 # ANSI color codes for output
 export RED='\033[0;31m'
 export GREEN='\033[0;32m'


### PR DESCRIPTION
This pull request implements Colette's initialization functionality and updates the Makefile. 

### Changes
- Creates a more flexible Makefile and changes C version enforcement to C99 from C11
- Implements `handleInit` handler function

### Init Mode
Init mode is a feature that allows a user to generate .index files for a new project as well as update .index files with new project files in an existing project. The idea is to make Colette more immediately usable, saving users from having to manually add all their project files to a series of .index files before they can compile their final document. With init mode, a user with a large pre-existing writing project can run Colette with the `--init` flag and immediately populate the project with .index files containing all project files. From there, they only need to order the filenames within the index files before collating.

Files are added to the .index files in alphabetical order based on the system's locale. Users can then reorder the files listed in the .index files however they want. When new files are added to the .index files, they are sorted into alphabetical order and appended to the end of the .index file, preserving the order of the files that are already included.